### PR TITLE
Problem with Scoll bar detection on IE

### DIFF
--- a/src/jquery.appear.js
+++ b/src/jquery.appear.js
@@ -87,7 +87,7 @@
     if(element.data(SCROLLER_KEY)) {
       return false;
     }
-    var overflow = element.css('overflow');
+    var overflow = element.css('overflow-y');
     if(overflow != 'scroll' && overflow != 'auto') {
       return false;
     }


### PR DESCRIPTION
After few hours of debugging, I found that some scroll bar setup were not detected on IE 11 when CSS on div look likes  { overflow-y: auto;
overflow-x: hidden; }.  So the appear/disapear event were never trigered  in some situation. Changing overflow to overflow-y solver the problem for vertical scrolling.
